### PR TITLE
[PR] Add a proper location block for static assets in wp-content

### DIFF
--- a/config/dev.news.wsu.edu.conf
+++ b/config/dev.news.wsu.edu.conf
@@ -22,6 +22,22 @@ server {
         try_files $uri $uri/ /index.php$is_args$args;
     }
 
+    # Serve static assets under wp-content directly. Because wp-content
+    # is one level up, we pass the requested data as an alias.
+    location ~* ^(/wp-content/)(.*)(\.js|css|png|jpg|jpeg|gif|ico)$ {
+        expires 24h;
+        alias /var/www/news.wsu.edu$1$2$3;
+        log_not_found off;
+    }
+
+    # Serve static assets under wp-content directly. Because wp-content
+    # is one level up, we pass the requested data as an alias.
+    location ~* ^(/Content/)(.*)(\.js|css|png|jpg|jpeg|gif|ico)$ {
+        expires 365d;
+        alias /var/www/news.wsu.edu$1$2$3;
+        log_not_found off;
+    }
+
     location ~ ^/Content/(.*)$ {
         alias /var/www/news.wsu.edu/Content/$1;
     }

--- a/config/news.wsu.edu.conf
+++ b/config/news.wsu.edu.conf
@@ -22,6 +22,22 @@ server {
         try_files $uri $uri/ /index.php$is_args$args;
     }
 
+    # Serve static assets under wp-content directly. Because wp-content
+    # is one level up, we pass the requested data as an alias.
+    location ~* ^(/wp-content/)(.*)(\.js|css|png|jpg|jpeg|gif|ico)$ {
+        expires 24h;
+        alias /var/www/news.wsu.edu$1$2$3;
+        log_not_found off;
+    }
+
+    # Serve static assets under wp-content directly. Because wp-content
+    # is one level up, we pass the requested data as an alias.
+    location ~* ^(/Content/)(.*)(\.js|css|png|jpg|jpeg|gif|ico)$ {
+        expires 365d;
+        alias /var/www/news.wsu.edu$1$2$3;
+        log_not_found off;
+    }
+
     location /googlee89733c65fb24f91.html {
         alias /var/www/news.wsu.edu/googlee89733c65fb24f91.html;
     }


### PR DESCRIPTION
Our previous wp-content location was catching static assets and not
adding the proper Expires header.
