### PR TITLE
[PR] Move Google font-face declarations into our stylesheet

### DIFF
--- a/wp-content/themes/wsu-news-twentythirteen/css/wsu-template.css
+++ b/wp-content/themes/wsu-news-twentythirteen/css/wsu-template.css
@@ -91,3 +91,70 @@ a:hover {color:#981e32;text-decoration:none;}
 .tint3b{color:#fcebda}
 .tint4a{color:#a7dee9}
 .tint4b{color:#e2f4f8}
+
+@font-face {
+	font-family: 'Bitter';
+	font-style: normal;
+	font-weight: 400;
+	src: local('Bitter-Regular'), url(http://themes.googleusercontent.com/static/fonts/bitter/v5/2PcBT6-VmYhQCus-O11S5-vvDin1pK8aKteLpeZ5c0A.woff) format('woff');
+}
+@font-face {
+	font-family: 'Bitter';
+	font-style: normal;
+	font-weight: 700;
+	src: local('Bitter-Bold'), url(http://themes.googleusercontent.com/static/fonts/bitter/v5/evC1haE-MsorTl_A7_uSGbO3LdcAZYWl9Si6vvxL-qU.woff) format('woff');
+}
+@font-face {
+	font-family: 'Open Sans Condensed';
+	font-style: normal;
+	font-weight: 300;
+	src: local('Open Sans Cond Light'), local('OpenSans-CondensedLight'), url(http://themes.googleusercontent.com/static/fonts/opensanscondensed/v7/gk5FxslNkTTHtojXrkp-xGAzD5WKQVN4wSyA0MYYi4rr7w4p9aSvGirXi6XmeXNA.woff) format('woff');
+}
+@font-face {
+	font-family: 'Open Sans Condensed';
+	font-style: normal;
+	font-weight: 700;
+	src: local('Open Sans Condensed Bold'), local('OpenSans-CondensedBold'), url(http://themes.googleusercontent.com/static/fonts/opensanscondensed/v7/gk5FxslNkTTHtojXrkp-xM6Eyu0BCqAfob_z3hhzRFzr7w4p9aSvGirXi6XmeXNA.woff) format('woff');
+}
+@font-face {
+	font-family: 'Open Sans Condensed';
+	font-style: italic;
+	font-weight: 300;
+	src: local('Open Sans Cond Light Italic'), local('OpenSans-CondensedLightItalic'), url(http://themes.googleusercontent.com/static/fonts/opensanscondensed/v7/jIXlqT1WKafUSwj6s9AzV6XnXbwdDC8wAz6IIzmCDUN2IY20qb3OO3nusUf_NB58.woff) format('woff');
+}
+@font-face {
+	font-family: 'Source Sans Pro';
+	font-style: normal;
+	font-weight: 300;
+	src: local('Source Sans Pro Light'), local('SourceSansPro-Light'), url(http://themes.googleusercontent.com/static/fonts/sourcesanspro/v7/toadOcfmlt9b38dHJxOBGMVNtom4QlEDNJaqqqzqdSs.woff) format('woff');
+}
+@font-face {
+	font-family: 'Source Sans Pro';
+	font-style: normal;
+	font-weight: 400;
+	src: local('Source Sans Pro'), local('SourceSansPro-Regular'), url(http://themes.googleusercontent.com/static/fonts/sourcesanspro/v7/ODelI1aHBYDBqgeIAH2zlNHq-FFgoDNV3GTKpHwuvtI.woff) format('woff');
+}
+@font-face {
+	font-family: 'Source Sans Pro';
+	font-style: normal;
+	font-weight: 700;
+	src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url(http://themes.googleusercontent.com/static/fonts/sourcesanspro/v7/toadOcfmlt9b38dHJxOBGIqjGYJUyOXcBwUQbRaNH6c.woff) format('woff');
+}
+@font-face {
+	font-family: 'Source Sans Pro';
+	font-style: italic;
+	font-weight: 300;
+	src: local('Source Sans Pro Light Italic'), local('SourceSansPro-LightIt'), url(http://themes.googleusercontent.com/static/fonts/sourcesanspro/v7/fpTVHK8qsXbIeTHTrnQH6H7XMO6S-yJpg1torQFmnv33rGVtsTkPsbDajuO5ueQw.woff) format('woff');
+}
+@font-face {
+	font-family: 'Source Sans Pro';
+	font-style: italic;
+	font-weight: 400;
+	src: local('Source Sans Pro Italic'), local('SourceSansPro-It'), url(http://themes.googleusercontent.com/static/fonts/sourcesanspro/v7/M2Jd71oPJhLKp0zdtTvoM_bce-VcyLJMRR1FC9qWbU8.woff) format('woff');
+}
+@font-face {
+	font-family: 'Source Sans Pro';
+	font-style: italic;
+	font-weight: 700;
+	src: local('Source Sans Pro Bold Italic'), local('SourceSansPro-BoldIt'), url(http://themes.googleusercontent.com/static/fonts/sourcesanspro/v7/fpTVHK8qsXbIeTHTrnQH6PgYMAt3u4NmhhzLLLPJ5qH3rGVtsTkPsbDajuO5ueQw.woff) format('woff');
+}

--- a/wp-content/themes/wsu-news-twentythirteen/functions.php
+++ b/wp-content/themes/wsu-news-twentythirteen/functions.php
@@ -9,7 +9,7 @@ class WSU_News_Twentythirteen {
 	/**
 	 * @var string Version of CSS / JS for cache breaking.
 	 */
-	var $script_version = '20140321-01';
+	var $script_version = '20140321-03';
 
 	/**
 	 * Hook in where needed when the theme is loaded.
@@ -49,11 +49,14 @@ class WSU_News_Twentythirteen {
 	 * Open Sans Condensed for quite a bit. There are a few things that still
 	 * use Source Sans Pro, so we should continue to include that.
 	 *
+	 * These font-face rules are now included in wsu-template.css so that we
+	 * don't need to go to a new domain to find them.
+	 *
 	 * @todo revisit use of Bitter.
 	 */
 	public function modify_header() {
 		wp_dequeue_style( 'twentythirteen-fonts' );
-		wp_enqueue_style( 'wsu-news-fonts', 'http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,300italic,400italic,700italic|Bitter:400,700|Open+Sans+Condensed:300,700,300italic', array(), null );
+		//wp_enqueue_style( 'wsu-news-fonts', 'http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,300italic,400italic,700italic|Bitter:400,700|Open+Sans+Condensed:300,700,300italic', array(), null );
 	}
 
 	/**


### PR DESCRIPTION
This avoids the extra DNS call. The WOFF files that are used don't
expire for a year, so we should have no trouble.
