### PR TITLE
[PR] Point to newly generated SSL certs

### DIFF
--- a/config/news.wsu.edu.conf
+++ b/config/news.wsu.edu.conf
@@ -29,8 +29,8 @@ server {
 
 	# Enable SSL
 	ssl                    on;
-	ssl_certificate        /etc/nginx/ssl/news.wsu.edu.cer;
-	ssl_certificate_key    /etc/nginx/ssl/news.wsu.edu.key;
+	ssl_certificate        /etc/nginx/ssl/news.wsu.edu.1.cer;
+	ssl_certificate_key    /etc/nginx/ssl/news.wsu.edu.1.key;
 
 	# Pick the allowed protocols
 	ssl_protocols                TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
We've revoked the old certs issued for news.wsu.edu due to the
openssl vulnerability announced yesterday
